### PR TITLE
feat: Install System Dependencies for the Frontend Tooling

### DIFF
--- a/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
@@ -163,16 +163,23 @@ build {
       "sudo curl -f https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o awscliv2.zip",
       "unzip awscliv2.zip",
       "sudo ./aws/install",
-      # airbase custom tooling
+      # airbase custom tooling - backend
       "sudo apt install software-properties-common python3 python3-pip -y",
       "echo 'alias python=python3' >> /home/ubuntu/.bashrc",
       "echo 'alias pip=pip3' >> /home/ubuntu/.bashrc",
       "python3 -m pip install --upgrade pip",
-      "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash" # Node Version Manager
-      "nvm install 20" # Node 20
-      "npm install -g pnpm" # Package manager
-      "pnpm install -g wrangler" # Cloudflare cli
-      "pnpm install -g @sentry/cli@2.17.4" # Sentry cli
+      # airbase custom tooling - frontend
+      "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash", # Node Version Manager
+      "export NVM_DIR=$HOME/.nvm",
+      "[ -s $NVM_DIR/nvm.sh ]",
+      ". $NVM_DIR/nvm.sh",
+      "nvm install 20", # Node 20
+      "npm install -g pnpm", # Package manager
+      "pnpm setup",
+      "export PNPM_HOME=/home/ubuntu/.local/share/pnpm",
+      "export PATH=$PNPM_HOME:$PATH",
+      "pnpm install -g wrangler", # Cloudflare cli
+      "pnpm install -g @sentry/cli@2.17.4", # Sentry cli
       "npx playwright install-deps", # System dependencies for playwright e2e testing
     ], var.custom_shell_commands)
   }

--- a/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
@@ -168,7 +168,12 @@ build {
       "echo 'alias python=python3' >> /home/ubuntu/.bashrc",
       "echo 'alias pip=pip3' >> /home/ubuntu/.bashrc",
       "python3 -m pip install --upgrade pip",
-      "npx playwright install-deps",
+      "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash" # Node Version Manager
+      "nvm install 20" # Node 20
+      "npm install -g pnpm" # Package manager
+      "pnpm install -g wrangler" # Cloudflare cli
+      "pnpm install -g @sentry/cli@2.17.4" # Sentry cli
+      "npx playwright install-deps", # System dependencies for playwright e2e testing
     ], var.custom_shell_commands)
   }
 

--- a/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
+++ b/images/ubuntu-jammy/github_agent.ubuntu.pkr.hcl
@@ -168,6 +168,7 @@ build {
       "echo 'alias python=python3' >> /home/ubuntu/.bashrc",
       "echo 'alias pip=pip3' >> /home/ubuntu/.bashrc",
       "python3 -m pip install --upgrade pip",
+      "npx playwright install-deps",
     ], var.custom_shell_commands)
   }
 

--- a/images/ubuntu-jammy/manifest.json
+++ b/images/ubuntu-jammy/manifest.json
@@ -26,7 +26,16 @@
       "artifact_id": "us-east-1:ami-0b26cebd1c224e5cd",
       "packer_run_uuid": "0c18767b-3cf6-b22f-5a56-6ce30bf18aa2",
       "custom_data": null
+    },
+    {
+      "name": "githubrunner",
+      "builder_type": "amazon-ebs",
+      "build_time": 1702367434,
+      "files": null,
+      "artifact_id": "us-east-1:ami-07b68a3c2abb588cc",
+      "packer_run_uuid": "a5ea2ea3-635e-cfc6-cdfb-ab4c2c9a9608",
+      "custom_data": null
     }
   ],
-  "last_run_uuid": "0c18767b-3cf6-b22f-5a56-6ce30bf18aa2"
+  "last_run_uuid": "a5ea2ea3-635e-cfc6-cdfb-ab4c2c9a9608"
 }


### PR DESCRIPTION
Installs system dependencies for playwright 
https://playwright.dev/docs/browsers#install-system-dependencies

We need node js to be installed as a pre-requisite for the `npx` command to work, but based on the readme it seems to be pre-installed.